### PR TITLE
Add IRC notification in post {} block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,4 +62,9 @@ pipeline {
       }
     }
   }
+  post {
+    changed {
+      ircNotification()
+    }
+  }
 }


### PR DESCRIPTION
There's more to add, here (flesh out publishing/archiving results, sending emails with the build results, etc.) but I wanted to clearly scope this.

@kimberlythegeek @davehunt @rpappalax r?

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/axe-selenium-python.stephend/1/console

<img width="1326" alt="screen shot 2018-03-29 at 1 47 53 pm" src="https://user-images.githubusercontent.com/387249/38112845-06de2cce-3358-11e8-9dbc-8fb3892e4f3d.png">
